### PR TITLE
Keep a trace of each routes return code if available

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Tiime\TestedRoutesCheckerBundle\IgnoredRoutesStorage;
 use Tiime\TestedRoutesCheckerBundle\RoutesChecker;
-use Tiime\TestedRoutesCheckerBundle\RouteStorage\FileRouteStorage;
 
 #[AsCommand(
     name: 'tiime:tested-routes-checker:check',
@@ -44,10 +44,10 @@ class CheckCommand extends Command
 
         /** @var string $routesToIgnoreFile */
         $routesToIgnoreFile = $input->getOption('routes-to-ignore');
-        $fileRouteStorage = new FileRouteStorage($routesToIgnoreFile);
+        $ignoredRoutesStorage = new IgnoredRoutesStorage($routesToIgnoreFile);
 
         try {
-            $routesToIgnore = $fileRouteStorage->getRoutes();
+            $routesToIgnore = $ignoredRoutesStorage->getRoutes();
         } catch (\InvalidArgumentException $e) {
             $io->warning('Unable to load the given file containing routes to ignore.');
         }
@@ -84,7 +84,7 @@ class CheckCommand extends Command
         $this->showTestedIgnoredRoutesSection($io, $testedIgnoredRoutes);
 
         if ($input->getOption('generate-baseline')) {
-            $fileRouteStorage
+            $ignoredRoutesStorage
                 ->saveRoute(
                     implode(\PHP_EOL, $untestedRoutes)
                 );

--- a/src/EventListener/KernelRequestListener.php
+++ b/src/EventListener/KernelRequestListener.php
@@ -20,6 +20,10 @@ final class KernelRequestListener
             return;
         }
 
-        $this->routeStorage->saveRoute($routeName);
+        if (null === $response = $event->getResponse()) {
+            return;
+        }
+
+        $this->routeStorage->saveRoute($routeName, $response->getStatusCode());
     }
 }

--- a/src/IgnoredRoutesStorage.php
+++ b/src/IgnoredRoutesStorage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tiime\TestedRoutesCheckerBundle;
+
+/**
+ * @internal
+ */
+final class IgnoredRoutesStorage
+{
+    public function __construct(
+        private readonly string $file,
+    ) {
+    }
+
+    public function saveRoute(string $route): void
+    {
+        if (!file_exists($this->file)) {
+            touch($this->file);
+        }
+
+        file_put_contents($this->file, "$route\n", \FILE_APPEND);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoutes(): array
+    {
+        if (!file_exists($this->file)) {
+            throw new \InvalidArgumentException("File \"{$this->file}\"does not exists, unable to load ignored routes!");
+        }
+
+        if (false === $routes = @file($this->file, \FILE_IGNORE_NEW_LINES)) {
+            throw new \RuntimeException('Unable to load ignored routes from given file.');
+        }
+
+        return array_unique($routes);
+    }
+}

--- a/src/RouteStorage/RouteStorageInterface.php
+++ b/src/RouteStorage/RouteStorageInterface.php
@@ -9,10 +9,13 @@ namespace Tiime\TestedRoutesCheckerBundle\RouteStorage;
  */
 interface RouteStorageInterface
 {
-    public function saveRoute(string $route): void;
+    public function saveRoute(string $route, int $statusCode): void;
 
     /**
-     * @return string[]
+     * Return an array with the route name as key and all known return codes
+     * (including duplicates).
+     *
+     * @return array<string, int[]>
      */
     public function getRoutes(): array;
 }

--- a/src/RoutesChecker.php
+++ b/src/RoutesChecker.php
@@ -24,7 +24,7 @@ final class RoutesChecker
     {
         $routesToIgnore = array_merge($this->getDefaultRoutesToIgnore(), $routesToIgnore);
 
-        $testedRoutes = $this->routeStorage->getRoutes();
+        $testedRoutes = array_keys($this->routeStorage->getRoutes());
 
         $routes = array_keys($this->router->getRouteCollection()->all());
         $untestedRoutes = array_diff($routes, $testedRoutes);
@@ -55,7 +55,7 @@ final class RoutesChecker
      */
     public function getTestedIgnoredRoutes(array $routesToIgnore = []): array
     {
-        $testedRoutes = $this->routeStorage->getRoutes();
+        $testedRoutes = array_keys($this->routeStorage->getRoutes());
 
         return array_values(array_intersect($testedRoutes, $routesToIgnore));
     }

--- a/tests/Fixtures/file_containing_one_route_per_row_with_duplicates
+++ b/tests/Fixtures/file_containing_one_route_per_row_with_duplicates
@@ -1,0 +1,7 @@
+route1
+route2
+route3
+route1
+route2
+route3
+route2

--- a/tests/IgnoredRoutesStorageTest.php
+++ b/tests/IgnoredRoutesStorageTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tiime\TestedRoutesCheckerBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Tiime\TestedRoutesCheckerBundle\IgnoredRoutesStorage;
+
+final class IgnoredRoutesStorageTest extends TestCase
+{
+    public function testStorage(): void
+    {
+        $storage = new IgnoredRoutesStorage(__DIR__.'/../var/cache/test_ignored_routes');
+
+        $storage->saveRoute('route1');
+        $storage->saveRoute('route2');
+        $storage->saveRoute('route3');
+        $storage->saveRoute('route2');
+
+        $this->assertSame(['route1', 'route2', 'route3'], $storage->getRoutes());
+    }
+}

--- a/tests/RouteStorage/FileRouteStorageTest.php
+++ b/tests/RouteStorage/FileRouteStorageTest.php
@@ -11,13 +11,28 @@ final class FileRouteStorageTest extends TestCase
 {
     public function testStorage(): void
     {
-        $storage = new FileRouteStorage(__DIR__.'/../../var/cache/test_cache_file');
+        $storage = new FileRouteStorage(__DIR__.'/../../var/cache/test_cache_file_'.bin2hex(random_bytes(5)));
 
-        $storage->saveRoute('route1');
-        $storage->saveRoute('route2');
-        $storage->saveRoute('route3');
-        $storage->saveRoute('route2');
+        $storage->saveRoute('route1', 200);
+        $storage->saveRoute('route2', 500);
+        $storage->saveRoute('route3', 403);
+        $storage->saveRoute('route2', 401);
 
-        $this->assertSame(['route1', 'route2', 'route3'], $storage->getRoutes());
+        $this->assertSame([
+            'route1' => [200],
+            'route2' => [500, 401],
+            'route3' => [403],
+        ], $storage->getRoutes());
+    }
+
+    public function testWithStorageWithoutStatusCode(): void
+    {
+        $storage = new FileRouteStorage(__DIR__.'/../Fixtures/file_containing_one_route_per_row_with_duplicates');
+
+        $this->assertSame([
+            'route1' => [200, 200],
+            'route2' => [200, 200, 200],
+            'route3' => [200, 200],
+        ], $storage->getRoutes());
     }
 }

--- a/tests/RoutesCheckerTest.php
+++ b/tests/RoutesCheckerTest.php
@@ -28,7 +28,7 @@ final class RoutesCheckerTest extends TestCase
     {
         $this->routeStorage->expects($this->once())
                 ->method('getRoutes')
-                ->willReturn(['route1', 'route2']);
+                ->willReturn(['route1' => [200], 'route2' => [404]]);
 
         $testedIgnoredRoutes = $this->routesChecker->getTestedIgnoredRoutes(['route2', 'route3']);
 


### PR DESCRIPTION
Thanks to this PR, we also store the return code associated to each response.
For now, this information is not used in the command, another PR will follow with a proposition.