### PR TITLE
Introduce "not successfully tested routes"

### DIFF
--- a/src/RoutesChecker.php
+++ b/src/RoutesChecker.php
@@ -7,7 +7,7 @@ namespace Tiime\TestedRoutesCheckerBundle;
 use Symfony\Component\Routing\RouterInterface;
 use Tiime\TestedRoutesCheckerBundle\RouteStorage\RouteStorageInterface;
 
-final class RoutesChecker
+class RoutesChecker
 {
     public function __construct(
         private readonly RouterInterface $router,

--- a/tests/Command/CheckCommandTest.php
+++ b/tests/Command/CheckCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tiime\TestedRoutesCheckerBundle\Tests\RouteStorage;
+namespace Tiime\TestedRoutesCheckerBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -15,6 +15,7 @@ final class CheckCommandTest extends TestCase
     {
         $routesChecker = $this->createMock(RoutesChecker::class);
         $routesChecker->expects($this->once())->method('getUntestedRoutes')->willReturn([]);
+        $routesChecker->expects($this->once())->method('getNotSuccessfullyTestedRoutes')->willReturn([]);
 
         $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
 
@@ -30,6 +31,7 @@ final class CheckCommandTest extends TestCase
     {
         $routesChecker = $this->createMock(RoutesChecker::class);
         $routesChecker->expects($this->once())->method('getUntestedRoutes')->willReturn(['route1', 'route2']);
+        $routesChecker->expects($this->once())->method('getNotSuccessfullyTestedRoutes')->willReturn([]);
 
         $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
 
@@ -39,5 +41,21 @@ final class CheckCommandTest extends TestCase
 
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('[ERROR] Found 2 non tested routes!', $output);
+    }
+
+    public function testWithNotSuccessfullyTestedRoutes(): void
+    {
+        $routesChecker = $this->createMock(RoutesChecker::class);
+        $routesChecker->expects($this->once())->method('getUntestedRoutes')->willReturn([]);
+        $routesChecker->expects($this->once())->method('getNotSuccessfullyTestedRoutes')->willReturn(['route3', 'route4']);
+
+        $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
+
+        $commandTester->execute([]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[WARNING] Found 2 routes which are not successfully tested', $output);
     }
 }

--- a/tests/Command/CheckCommandTest.php
+++ b/tests/Command/CheckCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tiime\TestedRoutesCheckerBundle\Tests\RouteStorage;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tiime\TestedRoutesCheckerBundle\Command\CheckCommand;
+use Tiime\TestedRoutesCheckerBundle\RoutesChecker;
+
+final class CheckCommandTest extends TestCase
+{
+    public function testWithoutUntestedRoutes(): void
+    {
+        $routesChecker = $this->createMock(RoutesChecker::class);
+        $routesChecker->expects($this->once())->method('getUntestedRoutes')->willReturn([]);
+
+        $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
+
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[OK] Congrats, all routes have been tested!', $output);
+    }
+
+    public function testWithUntestedRoutes(): void
+    {
+        $routesChecker = $this->createMock(RoutesChecker::class);
+        $routesChecker->expects($this->once())->method('getUntestedRoutes')->willReturn(['route1', 'route2']);
+
+        $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
+
+        $commandTester->execute([]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[ERROR] Found 2 non tested routes!', $output);
+    }
+}

--- a/tests/RoutesCheckerTest.php
+++ b/tests/RoutesCheckerTest.php
@@ -34,4 +34,15 @@ final class RoutesCheckerTest extends TestCase
 
         $this->assertSame(['route2'], $testedIgnoredRoutes);
     }
+
+    public function testGetNotFullyTesteRoutes(): void
+    {
+        $this->routeStorage->expects($this->once())
+                ->method('getRoutes')
+                ->willReturn(['route1' => [200], 'route2' => [404], 'route3' => [500]]);
+
+        $routes = $this->routesChecker->getNotSuccessfullyTestedRoutes(['route2', 'route4']);
+
+        $this->assertSame(['route3'], $routes);
+    }
 }


### PR DESCRIPTION
Starting from this PR, the command will fail if a route is not successfully tested (basically, 4xx & 5xx response code).

This behaviour is activated by default and can be disabled using `--ignore-not-successfully-tested-routes` (`-S`).