### PR TITLE
Allow to add not successfully tested routes in baseline

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -54,8 +54,8 @@ class CheckCommand extends Command
         }
 
         $untestedRoutes = $this->routesChecker->getUntestedRoutes($routesToIgnore);
-        $testedIgnoredRoutes = $this->routesChecker->getTestedIgnoredRoutes($routesToIgnore);
         $notSuccessfullyTestedRoutes = $this->routesChecker->getNotSuccessfullyTestedRoutes($routesToIgnore);
+        $testedIgnoredRoutes = $this->routesChecker->getTestedIgnoredRoutes(array_merge($routesToIgnore, $notSuccessfullyTestedRoutes));
 
         if (0 === $count = \count($untestedRoutes)) {
             if (0 < \count($testedIgnoredRoutes)) {

--- a/tests/Command/CheckCommandTest.php
+++ b/tests/Command/CheckCommandTest.php
@@ -46,7 +46,6 @@ final class CheckCommandTest extends TestCase
     public function testWithNotSuccessfullyTestedRoutes(): void
     {
         $routesChecker = $this->createMock(RoutesChecker::class);
-        $routesChecker->expects($this->once())->method('getUntestedRoutes')->willReturn([]);
         $routesChecker->expects($this->once())->method('getNotSuccessfullyTestedRoutes')->willReturn(['route3', 'route4']);
 
         $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
@@ -57,5 +56,20 @@ final class CheckCommandTest extends TestCase
 
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('[WARNING] Found 2 routes which are not successfully tested', $output);
+    }
+
+    public function testWithTestedIgnoredRoutes(): void
+    {
+        $routesChecker = $this->createMock(RoutesChecker::class);
+        $routesChecker->expects($this->once())->method('getTestedIgnoredRoutes')->willReturn(['route2']);
+
+        $commandTester = new CommandTester(new CheckCommand($routesChecker, 10, __DIR__.'/ignored_routes'));
+
+        $commandTester->execute([]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[WARNING] Some ignored routes looks tested', $output);
     }
 }


### PR DESCRIPTION
Does not fail if a not successfully tested route is added in baseline.